### PR TITLE
fix SkipList types to Vec[u8]

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Features
 
 See more in `plan.md`.
 
-## Related Benchmarks
+## Related
 
-<http://www.lmdb.tech/bench/microbench/benchmark.html>
+- LevelDB Benchmarks: <http://www.lmdb.tech/bench/microbench/benchmark.html>
+- LevelDB in Rust: <https://github.com/dermesser/leveldb-rs/tree/master>

--- a/benches/db_bench.rs
+++ b/benches/db_bench.rs
@@ -19,20 +19,22 @@ fn bench_db_insert(b: &mut Bencher) {
         fs::remove_file(&wal_path).expect("Failed to remove existing WAL file");
     }
 
-    // Initialize a new Database with key and value as i32
-    let mut db: DB<i32, i32> = DB::new(wal_path.to_str().unwrap(), 10);
+    // Initialize a new DB that expects raw bytes for key + value
+    // (e.g. DB::new(path, max_level))
+    let mut db = DB::new(wal_path.to_str().unwrap(), 10);
     let mut rng = rand::thread_rng();
 
     b.iter(|| {
-        // Generate a random key and use it as the value for simplicity
-        let key = rng.gen::<i32>();
-        db.put(key, key).unwrap();
+        let key_i32 = rng.gen::<i32>();
+        // Convert to big-endian bytes
+        let key_bytes = key_i32.to_be_bytes().to_vec();
+        // For the value, do the same (here we store the same i32 for simplicity)
+        db.put(key_bytes.clone(), key_bytes).unwrap();
     });
 }
 
 #[bench]
 fn bench_db_insert_existing(b: &mut Bencher) {
-    // Initialize a new SkipList with key and value as i32
     let dir = tempdir().expect("Failed to create temp dir");
     let wal_path = dir.path().join("wal_bench.log");
 
@@ -41,26 +43,27 @@ fn bench_db_insert_existing(b: &mut Bencher) {
         fs::remove_file(&wal_path).expect("Failed to remove existing WAL file");
     }
 
-    // Initialize a new Database with key and value as i32
-    let mut db: DB<i32, i32> = DB::new(wal_path.to_str().unwrap(), 10);
+    let mut db = DB::new(wal_path.to_str().unwrap(), 10);
     let mut rng = rand::thread_rng();
 
-    // Pre-populate the skip list with 1,000,000 elements
+    // Pre-populate the DB with 1,000,000 elements
+    // using random i32 -> bytes
     for _ in 0..1_000_000 {
-        let key = rng.gen::<i32>();
-        db.put(key, key).unwrap();
+        let key_i32 = rng.gen::<i32>();
+        let key_bytes = key_i32.to_be_bytes().to_vec();
+        db.put(key_bytes.clone(), key_bytes).unwrap();
     }
 
     b.iter(|| {
         // Insert additional elements
-        let key = rng.gen::<i32>();
-        db.put(key, key).unwrap();
+        let key_i32 = rng.gen::<i32>();
+        let key_bytes = key_i32.to_be_bytes().to_vec();
+        db.put(key_bytes.clone(), key_bytes).unwrap();
     });
 }
 
 #[bench]
 fn bench_db_get_existing(b: &mut Bencher) {
-    // Initialize a new SkipList with key and value as i32
     let dir = tempdir().expect("Failed to create temp dir");
     let wal_path = dir.path().join("wal_bench.log");
 
@@ -69,29 +72,31 @@ fn bench_db_get_existing(b: &mut Bencher) {
         fs::remove_file(&wal_path).expect("Failed to remove existing WAL file");
     }
 
-    // Initialize a new Database with key and value as i32
-    let mut db: DB<i32, i32> = DB::new(wal_path.to_str().unwrap(), 10);
+    let mut db = DB::new(wal_path.to_str().unwrap(), 10);
     let mut rng = rand::thread_rng();
+
+    // We'll store the i32 keys in a Vec so we can retrieve them randomly
     let mut keys = Vec::with_capacity(1_000_000);
 
-    // Pre-populate the skip list with 1,000,000 elements
+    // Pre-populate the DB with 1,000,000 elements
     for _ in 0..1_000_000 {
-        let key = rng.gen::<i32>();
-        db.put(key, key).unwrap();
-        keys.push(key);
+        let key_i32 = rng.gen::<i32>();
+        let key_bytes = key_i32.to_be_bytes().to_vec();
+        db.put(key_bytes.clone(), key_bytes.clone()).unwrap();
+        keys.push(key_i32);
     }
 
     b.iter(|| {
-        // Randomly select a key to retrieve
+        // Randomly select one of the known keys
         let index = rng.gen_range(0..keys.len());
-        let key = keys[index];
-        db.get(&key).unwrap();
+        let key_i32 = keys[index];
+        let key_bytes = key_i32.to_be_bytes().to_vec();
+        let _ = db.get(key_bytes).unwrap(); // We expect success here
     });
 }
 
 #[bench]
 fn bench_db_get_nonexistent(b: &mut Bencher) {
-    // Initialize a new SkipList with key and value as i32
     let dir = tempdir().expect("Failed to create temp dir");
     let wal_path = dir.path().join("wal_bench.log");
 
@@ -100,19 +105,20 @@ fn bench_db_get_nonexistent(b: &mut Bencher) {
         fs::remove_file(&wal_path).expect("Failed to remove existing WAL file");
     }
 
-    // Initialize a new Database with key and value as i32
-    let mut db: DB<i32, i32> = DB::new(wal_path.to_str().unwrap(), 10);
+    let mut db = DB::new(wal_path.to_str().unwrap(), 10);
     let mut rng = rand::thread_rng();
 
-    // Pre-populate the skip list with 1,000,000 elements
+    // Pre-populate with 1,000,000 elements
     for _ in 0..1_000_000 {
-        let key = rng.gen::<i32>();
-        db.put(key, key).unwrap();
+        let key_i32 = rng.gen::<i32>();
+        let key_bytes = key_i32.to_be_bytes().to_vec();
+        db.put(key_bytes.clone(), key_bytes).unwrap();
     }
 
     b.iter(|| {
-        // Generate a key that is unlikely to exist
-        let key = rng.gen::<i32>() + 1_000_000;
-        let _ = db.get(&key);
+        // Generate a key that's unlikely to exist
+        let missing_i32 = rng.gen::<i32>().wrapping_add(1_000_000);
+        let missing_bytes = missing_i32.to_be_bytes().to_vec();
+        let _ = db.get(missing_bytes);
     });
 }

--- a/benches/skiplist_bench.rs
+++ b/benches/skiplist_bench.rs
@@ -9,73 +9,78 @@ use test::Bencher;
 
 #[bench]
 fn bench_insert(b: &mut Bencher) {
-    // Initialize a new SkipList with key and value as i32
-    let mut skip_list: SkipList<i32, i32> = SkipList::new(20);
+    // Initialize a new SkipList with raw byte keys/values
+    let mut skip_list = SkipList::new(20);
     let mut rng = rand::thread_rng();
 
     b.iter(|| {
-        // Generate a random key and use it as the value for simplicity
-        let key = rng.gen::<i32>();
-        skip_list.put(key, key).unwrap();
+        // Generate a random i32 and convert to bytes
+        let key_i32 = rng.gen::<i32>();
+        let key_bytes = key_i32.to_be_bytes().to_vec();
+
+        // For simplicity, store the same data as the "value"
+        skip_list.put(key_bytes.clone(), key_bytes).unwrap();
     });
 }
 
 #[bench]
 fn bench_insert_existing(b: &mut Bencher) {
-    // Initialize a new SkipList with key and value as i32
-    let mut skip_list: SkipList<i32, i32> = SkipList::new(20);
+    let mut skip_list = SkipList::new(20);
     let mut rng = rand::thread_rng();
 
     // Pre-populate the skip list with 1,000,000 elements
     for _ in 0..1_000_000 {
-        let key = rng.gen::<i32>();
-        skip_list.put(key, key).unwrap();
+        let key_i32 = rng.gen::<i32>();
+        let key_bytes = key_i32.to_be_bytes().to_vec();
+        skip_list.put(key_bytes.clone(), key_bytes).unwrap();
     }
 
     b.iter(|| {
-        // Insert additional elements
-        let key = rng.gen::<i32>();
-        skip_list.put(key, key).unwrap();
+        let key_i32 = rng.gen::<i32>();
+        let key_bytes = key_i32.to_be_bytes().to_vec();
+        skip_list.put(key_bytes.clone(), key_bytes).unwrap();
     });
 }
 
 #[bench]
 fn bench_get_existing(b: &mut Bencher) {
-    // Initialize a new SkipList with key and value as i32
-    let mut skip_list: SkipList<i32, i32> = SkipList::new(20);
+    let mut skip_list = SkipList::new(20);
     let mut rng = rand::thread_rng();
     let mut keys = Vec::with_capacity(1_000_000);
 
     // Pre-populate the skip list with 1,000,000 elements
     for _ in 0..1_000_000 {
-        let key = rng.gen::<i32>();
-        skip_list.put(key, key).unwrap();
-        keys.push(key);
+        let key_i32 = rng.gen::<i32>();
+        let key_bytes = key_i32.to_be_bytes().to_vec();
+        skip_list.put(key_bytes.clone(), key_bytes.clone()).unwrap();
+        keys.push(key_i32); // Store the original i32 so we can retrieve it randomly
     }
 
     b.iter(|| {
         // Randomly select a key to retrieve
         let index = rng.gen_range(0..keys.len());
-        let key = keys[index];
-        skip_list.get(&key).unwrap();
+        let key_i32 = keys[index];
+        let key_bytes = key_i32.to_be_bytes().to_vec();
+        skip_list.get(key_bytes).unwrap();
     });
 }
 
 #[bench]
 fn bench_get_nonexistent(b: &mut Bencher) {
-    // Initialize a new SkipList with key and value as i32
-    let mut skip_list: SkipList<i32, i32> = SkipList::new(20);
+    let mut skip_list = SkipList::new(20);
     let mut rng = rand::thread_rng();
 
     // Pre-populate the skip list with 1,000,000 elements
     for _ in 0..1_000_000 {
-        let key = rng.gen::<i32>();
-        skip_list.put(key, key).unwrap();
+        let key_i32 = rng.gen::<i32>();
+        let key_bytes = key_i32.to_be_bytes().to_vec();
+        skip_list.put(key_bytes.clone(), key_bytes).unwrap();
     }
 
     b.iter(|| {
         // Generate a key that is unlikely to exist
-        let key = rng.gen::<i32>() + 1_000_000;
-        let _ = skip_list.get(&key);
+        let key_i32 = rng.gen::<i32>().wrapping_add(1_000_000);
+        let key_bytes = key_i32.to_be_bytes().to_vec();
+        let _ = skip_list.get(key_bytes);
     });
 }

--- a/benches/wal_bench.rs
+++ b/benches/wal_bench.rs
@@ -4,15 +4,14 @@
 
 extern crate test;
 
-use kv_db::KvPair; // Adjust the path based on your project structure
-use kv_db::Wal;
+use kv_db::{KvPair, Wal}; // Adjust the path if needed
 use rand::Rng;
 use std::fs;
-use tempfile::tempdir;
+use tempfile::{tempdir, TempDir};
 use test::Bencher;
 
 /// Helper function to initialize a temporary WAL
-fn setup_wal() -> (Wal, tempfile::TempDir) {
+fn setup_wal() -> (Wal, TempDir) {
     let dir = tempdir().expect("Failed to create temp dir");
     let wal_path = dir.path().join("wal_bench.log");
 
@@ -21,7 +20,7 @@ fn setup_wal() -> (Wal, tempfile::TempDir) {
         fs::remove_file(&wal_path).expect("Failed to remove existing WAL file");
     }
 
-    // Initialize the WAL
+    // Initialize the WAL (assuming Wal::new takes a String path)
     let wal = Wal::new(wal_path.to_str().unwrap().to_string()).expect("Failed to create WAL");
 
     (wal, dir)
@@ -31,13 +30,15 @@ fn setup_wal() -> (Wal, tempfile::TempDir) {
 #[bench]
 fn bench_wal_append(b: &mut Bencher) {
     let (mut wal, _dir) = setup_wal();
+
+    // Example key = "benchmark_key", value = 42, both as raw bytes
     let kv = KvPair {
-        key: "benchmark_key".to_string(),
-        value: 42,
+        key: b"benchmark_key".to_vec(),
+        value: 42i32.to_be_bytes().to_vec(),
     };
 
     b.iter(|| {
-        // Clone the KvPair to avoid borrowing issues
+        // `.clone()` because `append()` consumes the KvPair
         wal.append(kv.clone()).expect("Failed to append KvPair");
     });
 }
@@ -50,10 +51,11 @@ fn bench_wal_append_existing(b: &mut Bencher) {
 
     // Pre-populate the WAL with 1,000,000 entries
     for _ in 0..1_000_000 {
-        let key = rng.gen::<i32>().to_string();
+        let key_i32 = rng.gen::<i32>();
+        let val_i32 = rng.gen::<i32>();
         let kv = KvPair {
-            key,
-            value: rng.gen::<i32>(),
+            key: key_i32.to_be_bytes().to_vec(),
+            value: val_i32.to_be_bytes().to_vec(),
         };
         wal.append(kv)
             .expect("Failed to append pre-populated KvPair");
@@ -61,12 +63,11 @@ fn bench_wal_append_existing(b: &mut Bencher) {
 
     // Prepare a KvPair for benchmarking
     let benchmark_kv = KvPair {
-        key: "benchmark_key".to_string(),
-        value: 42,
+        key: b"benchmark_key".to_vec(),
+        value: 42i32.to_be_bytes().to_vec(),
     };
 
     b.iter(|| {
-        // Clone the KvPair to avoid borrowing issues
         wal.append(benchmark_kv.clone())
             .expect("Failed to append KvPair");
     });

--- a/plan.md
+++ b/plan.md
@@ -2,13 +2,23 @@
 
 ## TODO
 
-- db can start/stop and reload data from previous runs
-- store immutable data using sstables
-- improve sstables with lsm trees and leveled compaction
+### Core
+
+- store immutable data using sstables to provide complete persistence
+- create index for sstables to improve reads
+- do levelled compaction of sstables
 - bloom filter to improve read performance
+
+### Improvements
+
+- make WAL/Memtable writes atomic?
+  - what happens if we write to the WAL but not to the memtable?
+- make the types for the db easier to use
 
 ## Done
 
+- fix the types of the skip list - use `Vec<u8>` for both keys and values (bytes)?
+- db can start/stop and reload data from previous runs
 - create a WAL
 - add some ci (bench/test)
 - I'm pretty sure the skip list implementation is not exactly correct
@@ -18,6 +28,15 @@
 - node is key/value
 
 ## Notes
+
+### SSTables
+
+- we want to implement a 'flush' method on the Database(?)
+- this will create an `ImmutableSSTable` (TODO) object, and write the contents of the level 0 skip list to a file
+  - need to create some kind of threshold to know when to flush
+- On startup, we need to reload all the `ImmutableSSTable` objects, each having a reference to it's file
+- when we do a get, we need to search the current memtable (skip list) and also through the SSTables
+  - we search in reverse order, and return the first value that we find
 
 ### WAL
 

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -1,14 +1,15 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct KvPair<K, V> {
-    pub key: K,
-    pub value: V,
+
+pub struct KvPair {
+    pub key: Vec<u8>,
+    pub value: Vec<u8>,
 }
 
-impl<K, V> KvPair<K, V> {
+impl KvPair {
     /// Create a new KvPair
-    pub fn new(key: K, value: V) -> Self {
+    pub fn new(key: Vec<u8>, value: Vec<u8>) -> Self {
         Self { key, value }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,4 +7,5 @@ pub mod client;
 pub mod db;
 pub mod kv;
 pub mod skip_list;
+pub mod sstable;
 pub mod wal;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,5 +7,4 @@ pub mod client;
 pub mod db;
 pub mod kv;
 pub mod skip_list;
-pub mod sstable;
 pub mod wal;


### PR DESCRIPTION
reference rust leveldb uses Vec[u8] and it was getting annoying + unnecessary to be generic

https://github.com/dermesser/leveldb-rs/blob/master/src/skipmap.rs#L19